### PR TITLE
Fix RPM2 calculation with proper conversion

### DIFF
--- a/Main.vb
+++ b/Main.vb
@@ -1923,13 +1923,13 @@ Public Class Main
         DataActions(CORRECTED_EFFICIENCY) = Function(x) x.Corr_Efficiency
 
         DataTags(TEMPERATURE1) = "Temperature1"
-        DataUnitTags(TEMPERATURE1) = "°C"
+        DataUnitTags(TEMPERATURE1) = "Â°C"
         DataUnits(TEMPERATURE1, 0) = 1
         Data(TEMPERATURE1, MINIMUM) = 10000
         DataActions(TEMPERATURE1) = Function(x) x.Temperature1
 
         DataTags(TEMPERATURE2) = "Temperature2"
-        DataUnitTags(TEMPERATURE2) = "°C"
+        DataUnitTags(TEMPERATURE2) = "Â°C"
         DataUnits(TEMPERATURE2, 0) = 1
         Data(TEMPERATURE1, MINIMUM) = 10000
         DataActions(TEMPERATURE2) = Function(x) x.Temperature2
@@ -3082,7 +3082,7 @@ Public Class Main
                             RPM2NewTriggerTime = CDbl(COMPortMessage(3)) / 1000000
                             RPM2ElapsedTime = CDbl(COMPortMessage(4)) / 1000000
                             If RPM2NewTriggerTime <> RPM2OldTriggerTime Then
-                                Data(RPM2, ACTUAL) = ElapsedTimeToRadPerSec / RPM2ElapsedTime
+                                Data(RPM2, ACTUAL) = ElapsedTimeToRadPerSec2 / RPM2ElapsedTime 'Uses channel 2's signals-per-revolution factor
                                 Data(RPM2_RATIO, ACTUAL) = Data(RPM2, ACTUAL) / Data(RPM1_WHEEL, ACTUAL)
                                 Data(RPM2_ROLLOUT, ACTUAL) = WheelCircumference / Data(RPM2_RATIO, ACTUAL)
                                 If Data(RPM2, ACTUAL) > Data(RPM2, MAXIMUM) Then


### PR DESCRIPTION
## Summary
- use `ElapsedTimeToRadPerSec2` when computing RPM2
- comment that channel 2 uses its own signals‑per‑revolution factor

## Testing
- `dotnet build 'SimpleDyno 6.5.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5f7b9788333b5719404b7534e65